### PR TITLE
Release: Prepare for version 0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,39 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2025-05-26
+
+### Added
+
+- **Templated Default Values for Pipeline Inputs:**
+  - Input `default` values can now use template expressions with environment variables.
+  - Supports `${{ env.VARIABLE_NAME || 'fallback_literal' }}` syntax in input defaults.
+  - Enables dynamic default values based on environment configuration.
+  - Template expressions in defaults are evaluated once when the pipeline starts.
+  - Provides a powerful way to define "variables" in the pipeline that can be reused across multiple stacks.
+
+### Changed
+
+- **Enhanced Input Processing:**
+  - Input default values are now resolved and validated before the main template processor is initialized.
+  - Template expressions in input defaults are restricted to environment variables only (no stack outputs or other inputs).
+  - Improved error handling for malformed template expressions in input defaults.
+  - Added validation to ensure templated defaults resolve to values compatible with their declared input type.
+
+### Fixed
+
+- **Template Processing Improvements:**
+  - Fixed handling of unquoted literals in template expressions (e.g., numeric and boolean fallbacks).
+  - Improved `TemplateProcessor._resolve_single_part` to correctly handle unrecognized expressions as literal strings.
+  - Enhanced error specificity by catching `ManifestError` instead of generic `Exception` in template processing.
+
+### Documentation
+
+- **Updated README:**
+  - Added comprehensive documentation for templated default values in pipeline inputs.
+  - Enhanced examples showing environment variable usage in input defaults.
+  - Clarified the evaluation order and restrictions for templated defaults.
+
 ## [0.2.0] - 2025-05-26
 
 ### Added
@@ -191,7 +224,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Resolved circular import issue between `core.py` and `cli.py` by introducing `presentation.py`.
 - Corrected path handling for post-deployment scripts.
 
-[Unreleased]: https://github.com/dev7a/samstacks/compare/v0.1.4...HEAD
+[Unreleased]: https://github.com/dev7a/samstacks/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/dev7a/samstacks/compare/v0.2.0...v0.3.1
 [0.2.0]: https://github.com/dev7a/samstacks/compare/v0.1.4...v0.2.0
 [0.1.4]: https://github.com/dev7a/samstacks/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/dev7a/samstacks/compare/v0.1.2...v0.1.3

--- a/README.md
+++ b/README.md
@@ -283,7 +283,11 @@ pipeline_settings:
 
 **Input Properties:**
 - **`type`**: (Required) The input type. Supported types: `string`, `number`, `boolean`
-- **`default`**: (Optional) Default value if not provided via CLI. If no default is specified, the input is required
+- **`default`**: (Optional) Default value if not provided via CLI. If no default is specified, the input is required.
+    - The `default` value can be a literal (e.g., `dev`, `2`, `true`).
+    - It can also be a template string using environment variables, allowing for dynamic defaults: 
+      `${{ env.MY_DEFAULT_ENV_VAR || 'literal_fallback' }}`.
+    - Currently, only `${{ env... }}` expressions (with optional `||` fallbacks to literals) are supported within default value templates. These are evaluated once when the pipeline starts.
 - **`description`**: (Optional) Human-readable description of the input's purpose
 
 **CLI Usage:**

--- a/examples/inputs-pipeline.yml
+++ b/examples/inputs-pipeline.yml
@@ -12,7 +12,7 @@ pipeline_settings:
       description: "Target deployment environment (e.g., dev, staging, prod)"
     message_retention_override: # Example numeric input
       type: number
-      default: ${{ env.MESSAGE_RETENTION || 7200 }} 
+      default: "${{ env.MESSAGE_RETENTION || 7200 }}" 
       description: "SQS message retention in seconds. Overrides default."
     deploy_storage_stack: # Example boolean input
       type: boolean

--- a/examples/inputs-pipeline.yml
+++ b/examples/inputs-pipeline.yml
@@ -12,7 +12,7 @@ pipeline_settings:
       description: "Target deployment environment (e.g., dev, staging, prod)"
     message_retention_override: # Example numeric input
       type: number
-      default: ${{ env.MESSAGE_RETENTION || 7200 }} 
+      default: ${{ env.MESSAGE_RETENTION || hello }} 
       description: "SQS message retention in seconds. Overrides default."
     deploy_storage_stack: # Example boolean input
       type: boolean

--- a/examples/inputs-pipeline.yml
+++ b/examples/inputs-pipeline.yml
@@ -12,7 +12,7 @@ pipeline_settings:
       description: "Target deployment environment (e.g., dev, staging, prod)"
     message_retention_override: # Example numeric input
       type: number
-      default: ${{ env.MESSAGE_RETENTION || hello }} 
+      default: ${{ env.MESSAGE_RETENTION || 7200 }} 
       description: "SQS message retention in seconds. Overrides default."
     deploy_storage_stack: # Example boolean input
       type: boolean

--- a/examples/inputs-pipeline.yml
+++ b/examples/inputs-pipeline.yml
@@ -12,7 +12,7 @@ pipeline_settings:
       description: "Target deployment environment (e.g., dev, staging, prod)"
     message_retention_override: # Example numeric input
       type: number
-      default: 1209600 # Default from original example SQS queue
+      default: ${{ env.MESSAGE_RETENTION || 7200 }} 
       description: "SQS message retention in seconds. Overrides default."
     deploy_storage_stack: # Example boolean input
       type: boolean
@@ -43,6 +43,8 @@ stacks:
       # Test the setup by uploading a test file
       echo "Testing the pipeline by uploading a test file..."
       echo "Hello from samstacks in ${{ inputs.deployment_env }}!" > /tmp/test-file-${{ inputs.deployment_env }}.txt
-      aws s3 cp /tmp/test-file-${{ inputs.deployment_env }}.txt "s3://${{ stacks.storage.outputs.BucketName }}/test-file-${{ inputs.deployment_env }}.txt"
+      s3_file_url="s3://${{ stacks.storage.outputs.BucketName }}/test-file-${{ inputs.deployment_env }}.txt"
+      aws s3 cp /tmp/test-file-${{ inputs.deployment_env }}.txt "$s3_file_url"
       echo "Test file uploaded. Check CloudWatch logs for the Lambda function."
       rm /tmp/test-file-${{ inputs.deployment_env }}.txt 
+      aws s3 rm "$s3_file_url"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ path = "samstacks/version.py"
 
 [project]
 name = "samstacks"
-version = "0.2.0"
+version = "0.3.1"
 description = "Deploy a pipeline of AWS SAM stacks"
 readme = "README.md"
 license = "MIT"

--- a/samstacks/constants.py
+++ b/samstacks/constants.py
@@ -1,0 +1,8 @@
+"""
+Shared constants for the samstacks package.
+"""
+
+import re
+
+# Regex pattern for detecting template strings like ${{ ... }}
+TEMPLATE_PATTERN = re.compile(r"^\$\{\{.*\}\}$")

--- a/samstacks/core.py
+++ b/samstacks/core.py
@@ -26,7 +26,7 @@ from .exceptions import (
     StackDeploymentError,
     TemplateError,
 )
-from .input_utils import process_cli_input_value, _coerce_and_validate_value
+from .input_utils import process_cli_input_value, coerce_and_validate_value
 from .templating import TemplateProcessor
 from .validation import ManifestValidator, LineNumberTracker
 from .aws_utils import (
@@ -167,7 +167,7 @@ class Pipeline:
                             )
 
                         # Now coerce and validate this resolved string against the input's type
-                        coerced_default = _coerce_and_validate_value(
+                        coerced_default = coerce_and_validate_value(
                             resolved_default_str,
                             input_name,
                             input_def,

--- a/samstacks/core.py
+++ b/samstacks/core.py
@@ -171,7 +171,7 @@ class Pipeline:
                             resolved_default_str,
                             input_name,
                             input_def,
-                            value_source=f"Default value for input '{input_name}'",
+                            value_source="Default value",
                         )
                         # Update the input definition with the resolved and coerced default
                         self.defined_inputs[input_name]["default"] = coerced_default
@@ -180,7 +180,7 @@ class Pipeline:
                         raise ManifestError(
                             f"Error processing templated default for input '{input_name}': {e}"
                         ) from e
-                    # ManifestError from _coerce_and_validate_value will propagate directly
+                    # ManifestError from coerce_and_validate_value will propagate directly
 
         # Template processor for handling substitutions in the rest of the pipeline
         self.template_processor = TemplateProcessor(

--- a/samstacks/input_utils.py
+++ b/samstacks/input_utils.py
@@ -2,7 +2,7 @@
 Utility functions for processing CLI input values.
 """
 
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from .exceptions import ManifestError
 
@@ -19,7 +19,7 @@ def coerce_and_validate_value(
         value: The value to process (can be str, int, float, bool).
         input_name: Name of the input.
         input_definition: Input definition from manifest.
-        value_source: Description of the value's origin (e.g., 'default', 'CLI').
+        value_source: Description of the value's origin (e.g., 'Default value', 'CLI').
 
     Returns:
         The coerced value matching the input type.
@@ -64,7 +64,7 @@ def coerce_and_validate_value(
 
 def process_cli_input_value(
     input_name: str, cli_value: str, input_definition: Dict[str, Any]
-) -> Any:
+) -> Optional[Any]:
     """
     Process and validate a CLI input value string.
 

--- a/samstacks/input_utils.py
+++ b/samstacks/input_utils.py
@@ -40,7 +40,7 @@ def coerce_and_validate_value(
             return num_value
         except (ValueError, TypeError):
             raise ManifestError(
-                f"{value_source.capitalize()} for input '{input_name}' must be a number. Received: '{value}'"
+                f"{value_source.upper()} for input '{input_name}' must be a number. Received: '{value}'"
             )
     elif input_type == "boolean":
         if isinstance(value, bool):
@@ -55,7 +55,7 @@ def coerce_and_validate_value(
         # Manifest validator ensures default is bool if type is bool. CLI inputs are strings.
         # This function might receive already coerced bools from defaults.
         raise ManifestError(
-            f"{value_source.capitalize()} for input '{input_name}' must be a boolean. Received: '{value}'"
+            f"{value_source.upper()} for input '{input_name}' must be a boolean. Received: '{value}'"
         )
     else:
         # Should not be reached if manifest validation is correct

--- a/samstacks/input_utils.py
+++ b/samstacks/input_utils.py
@@ -7,7 +7,7 @@ from typing import Any, Dict
 from .exceptions import ManifestError
 
 
-def _coerce_and_validate_value(
+def coerce_and_validate_value(
     value: Any,
     input_name: str,
     input_definition: Dict[str, Any],
@@ -87,6 +87,6 @@ def process_cli_input_value(
         return None
 
     # Coerce and validate the trimmed string value
-    return _coerce_and_validate_value(
+    return coerce_and_validate_value(
         trimmed_value, input_name, input_definition, value_source="CLI"
     )

--- a/samstacks/input_utils.py
+++ b/samstacks/input_utils.py
@@ -2,59 +2,91 @@
 Utility functions for processing CLI input values.
 """
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict
 
 from .exceptions import ManifestError
 
 
+def _coerce_and_validate_value(
+    value: Any,
+    input_name: str,
+    input_definition: Dict[str, Any],
+    value_source: str = "value",
+) -> Any:
+    """Coerce and validate a given value against the input definition.
+
+    Args:
+        value: The value to process (can be str, int, float, bool).
+        input_name: Name of the input.
+        input_definition: Input definition from manifest.
+        value_source: Description of the value's origin (e.g., 'default', 'CLI').
+
+    Returns:
+        The coerced value matching the input type.
+
+    Raises:
+        ManifestError: If the value cannot be coerced to the expected type.
+    """
+    input_type = input_definition.get("type", "string")
+
+    if input_type == "string":
+        return str(value)
+    elif input_type == "number":
+        try:
+            # Attempt to convert to float first, then to int if it's a whole number
+            num_value = float(value)
+            if num_value.is_integer():
+                return int(num_value)
+            return num_value
+        except (ValueError, TypeError):
+            raise ManifestError(
+                f"{value_source.capitalize()} for input '{input_name}' must be a number. Received: '{value}'"
+            )
+    elif input_type == "boolean":
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, str):
+            val_lower = value.lower()
+            if val_lower in ("true", "yes", "1", "on"):
+                return True
+            if val_lower in ("false", "no", "0", "off"):
+                return False
+        # If it's an int/float, 0 is false, non-zero is true is a common convention, but let's be strict to manifest types.
+        # Manifest validator ensures default is bool if type is bool. CLI inputs are strings.
+        # This function might receive already coerced bools from defaults.
+        raise ManifestError(
+            f"{value_source.capitalize()} for input '{input_name}' must be a boolean. Received: '{value}'"
+        )
+    else:
+        # Should not be reached if manifest validation is correct
+        raise ManifestError(f"Unknown type '{input_type}' for input '{input_name}'.")
+
+
 def process_cli_input_value(
     input_name: str, cli_value: str, input_definition: Dict[str, Any]
-) -> Optional[str]:
+) -> Any:
     """
-    Process and validate a CLI input value.
+    Process and validate a CLI input value string.
 
     Args:
         input_name: Name of the input
-        cli_value: Raw CLI input value
+        cli_value: Raw CLI input value string
         input_definition: Input definition from manifest
 
     Returns:
-        Processed CLI value (trimmed) or None if value is whitespace-only
+        Processed and coerced CLI value, or None if value is whitespace-only.
 
     Raises:
-        ManifestError: If the value doesn't match the expected type
+        ManifestError: If the value doesn't match the expected type.
     """
     # Trim whitespace
     trimmed_value = cli_value.strip()
 
-    # Treat whitespace-only as not provided
+    # Treat whitespace-only as not provided, returning None
     if not trimmed_value:
         return None
 
-    # Validate type
-    input_type = input_definition.get("type", "string")
-
-    if input_type == "number":
-        try:
-            float(trimmed_value)  # Check if convertible to float (int or float)
-        except ValueError:
-            raise ManifestError(
-                f"Input '{input_name}' must be a number. Received: '{trimmed_value}'"
-            )
-    elif input_type == "boolean":
-        if trimmed_value.lower() not in (
-            "true",
-            "false",
-            "yes",
-            "no",
-            "1",
-            "0",
-            "on",
-            "off",
-        ):
-            raise ManifestError(
-                f"Input '{input_name}' must be a boolean. Received: '{trimmed_value}'"
-            )
-    # String type needs no specific validation
-
-    return trimmed_value
+    # Coerce and validate the trimmed string value
+    return _coerce_and_validate_value(
+        trimmed_value, input_name, input_definition, value_source="CLI"
+    )

--- a/samstacks/input_utils.py
+++ b/samstacks/input_utils.py
@@ -40,7 +40,7 @@ def coerce_and_validate_value(
             return num_value
         except (ValueError, TypeError):
             raise ManifestError(
-                f"{value_source.upper()} for input '{input_name}' must be a number. Received: '{value}'"
+                f"{value_source.upper()} must be a number. Received: '{value}'"
             )
     elif input_type == "boolean":
         if isinstance(value, bool):
@@ -55,7 +55,7 @@ def coerce_and_validate_value(
         # Manifest validator ensures default is bool if type is bool. CLI inputs are strings.
         # This function might receive already coerced bools from defaults.
         raise ManifestError(
-            f"{value_source.upper()} for input '{input_name}' must be a boolean. Received: '{value}'"
+            f"{value_source.upper()} must be a boolean. Received: '{value}'"
         )
     else:
         # Should not be reached if manifest validation is correct

--- a/samstacks/templating.py
+++ b/samstacks/templating.py
@@ -111,12 +111,10 @@ class TemplateProcessor:
         ):
             return part_expression[1:-1]  # Strip quotes
 
-        # If not env, stacks, or literal, it's an unknown type for now
-        # For it to be part of a fallback chain like ${{ VAR1 || VAR2 }}, VAR1 must resolve.
-        # An unquoted string that is not env. or stacks. is effectively an undefined variable.
-        # Let's treat it as None to allow fallback. If it's the only item, it will become "".
-        # An unknown input like 'inputs.nonexistent' will also return None via _evaluate_pipeline_input.
-        return None
+        # If not env, stacks, inputs, or quoted literal, treat as an unquoted literal string.
+        # This allows for fallbacks like ${{ env.VAR || my_literal_fallback }}
+        # or even just ${{ my_literal_if_no_special_chars_that_need_quoting }}.
+        return part_expression
 
     def _evaluate_stack_output(self, expression: str) -> str | None:
         """Evaluate a stack output expression: stacks.stack_id.outputs.output_name.

--- a/samstacks/validation.py
+++ b/samstacks/validation.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import yaml
 
+from .constants import TEMPLATE_PATTERN
 from .exceptions import ManifestError
 
 
@@ -413,8 +414,8 @@ class ManifestValidator:
         """Check if a value is a string matching the template pattern '${{...}}'."""
         if not isinstance(value, str):
             return False
-        # Simple check for ${{...}}
-        return bool(re.match(r"^\$\{\{.*\}\}$", value.strip()))
+        # Use shared template pattern
+        return bool(TEMPLATE_PATTERN.match(value.strip()))
 
     def _validate_template_expressions_in_value(
         self,

--- a/samstacks/validation.py
+++ b/samstacks/validation.py
@@ -409,6 +409,13 @@ class ManifestValidator:
 
         return previous_row[-1]
 
+    def _is_string_template(self, value: Any) -> bool:
+        """Check if a value is a string matching the template pattern '${{...}}'."""
+        if not isinstance(value, str):
+            return False
+        # Simple check for ${{...}}
+        return bool(re.match(r"^\$\{\{.*\}\}$", value.strip()))
+
     def _validate_template_expressions_in_value(
         self,
         value: Any,
@@ -712,7 +719,12 @@ class ManifestValidator:
         Returns:
             tuple[bool, str]: (is_valid, error_message)
         """
-        # First check if it's a primitive type
+        # If the default value is a template string, skip type validation here.
+        # The TemplateProcessor will resolve it, and its type will be checked later.
+        if self._is_string_template(default_value):
+            return True, ""  # Considered valid at this stage
+
+        # First check if it's a primitive type (non-template values)
         if not isinstance(default_value, (str, int, float, bool)):
             return False, "field 'default' value must be a primitive type"
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -77,7 +77,7 @@ class TestPipelineValidation:
         cli_inputs = {"count": "not-a-number"}
         with pytest.raises(
             ManifestError,
-            match=r"CLI for input 'count' must be a number. Received: 'not-a-number'",
+            match=r"CLI must be a number. Received: 'not-a-number'",
         ):
             pipeline = Pipeline.from_dict(manifest_data, cli_inputs=cli_inputs)
             pipeline.validate()
@@ -102,7 +102,7 @@ class TestPipelineValidation:
         cli_inputs = {"enabled": "maybe"}
         with pytest.raises(
             ManifestError,
-            match=r"CLI for input 'enabled' must be a boolean. Received: 'maybe'",
+            match=r"CLI must be a boolean. Received: 'maybe'",
         ):
             pipeline = Pipeline.from_dict(manifest_data, cli_inputs=cli_inputs)
             pipeline.validate()
@@ -337,7 +337,7 @@ class TestPipelineValidation:
         }
         with pytest.raises(
             ManifestError,
-            match=r"DEFAULT VALUE for input 'bad_num_input' must be a number. Received: 'not_a_number_string'",
+            match=r"DEFAULT VALUE must be a number. Received: 'not_a_number_string'",
         ):
             Pipeline.from_dict(manifest_data)
 
@@ -357,7 +357,7 @@ class TestPipelineValidation:
         }
         with pytest.raises(
             ManifestError,
-            match=r"DEFAULT VALUE for input 'bad_bool_input' must be a boolean. Received: 'not_a_valid_boolean_string'",
+            match=r"DEFAULT VALUE must be a boolean. Received: 'not_a_valid_boolean_string'",
         ):
             Pipeline.from_dict(manifest_data)
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -77,7 +77,7 @@ class TestPipelineValidation:
         cli_inputs = {"count": "not-a-number"}
         with pytest.raises(
             ManifestError,
-            match=r"Cli for input 'count' must be a number. Received: 'not-a-number'",
+            match=r"CLI for input 'count' must be a number. Received: 'not-a-number'",
         ):
             pipeline = Pipeline.from_dict(manifest_data, cli_inputs=cli_inputs)
             pipeline.validate()
@@ -102,7 +102,7 @@ class TestPipelineValidation:
         cli_inputs = {"enabled": "maybe"}
         with pytest.raises(
             ManifestError,
-            match=r"Cli for input 'enabled' must be a boolean. Received: 'maybe'",
+            match=r"CLI for input 'enabled' must be a boolean. Received: 'maybe'",
         ):
             pipeline = Pipeline.from_dict(manifest_data, cli_inputs=cli_inputs)
             pipeline.validate()
@@ -337,7 +337,7 @@ class TestPipelineValidation:
         }
         with pytest.raises(
             ManifestError,
-            match=r"Default value for input 'bad_num_input'.*must be a number. Received: 'not_a_number_string'",
+            match=r"DEFAULT VALUE for input 'bad_num_input' must be a number. Received: 'not_a_number_string'",
         ):
             Pipeline.from_dict(manifest_data)
 
@@ -357,7 +357,7 @@ class TestPipelineValidation:
         }
         with pytest.raises(
             ManifestError,
-            match=r"Default value for input 'bad_bool_input'.*must be a boolean. Received: 'not_a_valid_boolean_string'",
+            match=r"DEFAULT VALUE for input 'bad_bool_input' must be a boolean. Received: 'not_a_valid_boolean_string'",
         ):
             Pipeline.from_dict(manifest_data)
 

--- a/tests/test_input_utils.py
+++ b/tests/test_input_utils.py
@@ -56,7 +56,7 @@ class TestProcessCliInputValue:
         definition = {"type": "number"}
         with pytest.raises(
             ManifestError,
-            match=r"CLI for input 'test_input' must be a number. Received: 'not_a_number'",
+            match=r"CLI must be a number. Received: 'not_a_number'",
         ):
             process_cli_input_value("test_input", "not_a_number", definition)
 
@@ -85,7 +85,7 @@ class TestProcessCliInputValue:
         definition = {"type": "boolean"}
         with pytest.raises(
             ManifestError,
-            match=r"CLI for input 'test_input' must be a boolean. Received: 'maybe'",
+            match=r"CLI must be a boolean. Received: 'maybe'",
         ):
             process_cli_input_value("test_input", "maybe", definition)
 

--- a/tests/test_input_utils.py
+++ b/tests/test_input_utils.py
@@ -34,37 +34,58 @@ class TestProcessCliInputValue:
         result = process_cli_input_value("test_input", "", definition)
         assert result is None
 
-    @pytest.mark.parametrize("valid_number", ["123", "3.14", "-5", "0", "42.0"])
-    def test_number_input_valid(self, valid_number: str):
-        """Test processing valid number inputs."""
+    @pytest.mark.parametrize(
+        "valid_number_str, expected_value",
+        [
+            ("123", 123),
+            ("3.14", 3.14),
+            ("-5", -5),
+            ("0", 0),
+            ("42.0", 42),  # float 42.0 becomes int 42
+        ],
+    )
+    def test_number_input_valid(self, valid_number_str: str, expected_value: any):
+        """Test processing valid number inputs returns coerced numeric types."""
         definition = {"type": "number"}
-        result = process_cli_input_value("test_input", valid_number, definition)
-        assert result == valid_number
+        result = process_cli_input_value("test_input", valid_number_str, definition)
+        assert result == expected_value
+        assert isinstance(result, (int, float))
 
     def test_number_input_invalid(self):
         """Test that invalid number input raises ManifestError."""
         definition = {"type": "number"}
         with pytest.raises(
             ManifestError,
-            match="Input 'test_input' must be a number. Received: 'not_a_number'",
+            match=r"Cli for input 'test_input' must be a number. Received: 'not_a_number'",
         ):
             process_cli_input_value("test_input", "not_a_number", definition)
 
     @pytest.mark.parametrize(
-        "valid_bool", ["true", "FALSE", "yes", "NO", "1", "0", "on", "OFF"]
+        "valid_bool_str, expected_value",
+        [
+            ("true", True),
+            ("FALSE", False),
+            ("yes", True),
+            ("NO", False),
+            ("1", True),
+            ("0", False),
+            ("on", True),
+            ("OFF", False),
+        ],
     )
-    def test_boolean_input_valid(self, valid_bool: str):
-        """Test processing valid boolean inputs."""
+    def test_boolean_input_valid(self, valid_bool_str: str, expected_value: bool):
+        """Test processing valid boolean inputs returns coerced boolean types."""
         definition = {"type": "boolean"}
-        result = process_cli_input_value("test_input", valid_bool, definition)
-        assert result == valid_bool  # Returns the original trimmed value, not converted
+        result = process_cli_input_value("test_input", valid_bool_str, definition)
+        assert result == expected_value
+        assert isinstance(result, bool)
 
     def test_boolean_input_invalid(self):
         """Test that invalid boolean input raises ManifestError."""
         definition = {"type": "boolean"}
         with pytest.raises(
             ManifestError,
-            match="Input 'test_input' must be a boolean. Received: 'maybe'",
+            match=r"Cli for input 'test_input' must be a boolean. Received: 'maybe'",
         ):
             process_cli_input_value("test_input", "maybe", definition)
 
@@ -78,10 +99,12 @@ class TestProcessCliInputValue:
         """Test that number input is trimmed and then validated."""
         definition = {"type": "number"}
         result = process_cli_input_value("test_input", "  42.5  ", definition)
-        assert result == "42.5"
+        assert result == 42.5
+        assert isinstance(result, float)
 
     def test_boolean_with_whitespace_trimmed_and_validated(self):
         """Test that boolean input is trimmed and then validated."""
         definition = {"type": "boolean"}
         result = process_cli_input_value("test_input", "  true  ", definition)
-        assert result == "true"
+        assert result is True
+        assert isinstance(result, bool)

--- a/tests/test_input_utils.py
+++ b/tests/test_input_utils.py
@@ -56,7 +56,7 @@ class TestProcessCliInputValue:
         definition = {"type": "number"}
         with pytest.raises(
             ManifestError,
-            match=r"Cli for input 'test_input' must be a number. Received: 'not_a_number'",
+            match=r"CLI for input 'test_input' must be a number. Received: 'not_a_number'",
         ):
             process_cli_input_value("test_input", "not_a_number", definition)
 
@@ -85,7 +85,7 @@ class TestProcessCliInputValue:
         definition = {"type": "boolean"}
         with pytest.raises(
             ManifestError,
-            match=r"Cli for input 'test_input' must be a boolean. Received: 'maybe'",
+            match=r"CLI for input 'test_input' must be a boolean. Received: 'maybe'",
         ):
             process_cli_input_value("test_input", "maybe", definition)
 

--- a/tests/test_templating.py
+++ b/tests/test_templating.py
@@ -511,7 +511,7 @@ class TestTemplateProcessor:
         )
         with pytest.raises(
             TemplateError,
-            match=r"CLI for input 'strict_bool' must be a boolean. Received: 'not_a_bool'",
+            match=r"CLI must be a boolean. Received: 'not_a_bool'",
         ):
             processor.process_string("Value: ${{ inputs.strict_bool }}")
 
@@ -526,7 +526,7 @@ class TestTemplateProcessor:
         # The error comes from float() conversion in _evaluate_pipeline_input
         with pytest.raises(
             TemplateError,
-            match=r"CLI for input 'strict_num' must be a number. Received: 'not_a_number'",
+            match=r"CLI must be a number. Received: 'not_a_number'",
         ):
             processor.process_string("Value: ${{ inputs.strict_num }}")
 

--- a/tests/test_templating.py
+++ b/tests/test_templating.py
@@ -511,7 +511,7 @@ class TestTemplateProcessor:
         )
         with pytest.raises(
             TemplateError,
-            match=r"Input 'strict_bool' must be a boolean. Received: 'not_a_bool'",
+            match=r"Cli for input 'strict_bool' must be a boolean. Received: 'not_a_bool'",
         ):
             processor.process_string("Value: ${{ inputs.strict_bool }}")
 
@@ -526,7 +526,7 @@ class TestTemplateProcessor:
         # The error comes from float() conversion in _evaluate_pipeline_input
         with pytest.raises(
             TemplateError,
-            match=r"Input 'strict_num' must be a number. Received: 'not_a_number'",
+            match=r"Cli for input 'strict_num' must be a number. Received: 'not_a_number'",
         ):
             processor.process_string("Value: ${{ inputs.strict_num }}")
 

--- a/tests/test_templating.py
+++ b/tests/test_templating.py
@@ -511,7 +511,7 @@ class TestTemplateProcessor:
         )
         with pytest.raises(
             TemplateError,
-            match=r"Cli for input 'strict_bool' must be a boolean. Received: 'not_a_bool'",
+            match=r"CLI for input 'strict_bool' must be a boolean. Received: 'not_a_bool'",
         ):
             processor.process_string("Value: ${{ inputs.strict_bool }}")
 
@@ -526,7 +526,7 @@ class TestTemplateProcessor:
         # The error comes from float() conversion in _evaluate_pipeline_input
         with pytest.raises(
             TemplateError,
-            match=r"Cli for input 'strict_num' must be a number. Received: 'not_a_number'",
+            match=r"CLI for input 'strict_num' must be a number. Received: 'not_a_number'",
         ):
             processor.process_string("Value: ${{ inputs.strict_num }}")
 


### PR DESCRIPTION
This pull request introduces a new feature for templated default values in pipeline inputs, improves input processing, and enhances template handling. It also includes updates to documentation, examples, and tests to reflect these changes.

### New Features
* **Templated Default Values for Pipeline Inputs**: Input `default` values can now use template expressions with environment variables, enabling dynamic defaults such as `${{ env.VARIABLE_NAME || 'fallback_literal' }}`. These templates are evaluated once when the pipeline starts. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R40) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L286-R290) [[3]](diffhunk://#diff-e6b7ded6e98a8d195097ee13de6573164a1d6a877eb7505959709fac2a237159L15-R15)

### Enhancements
* **Input Processing Improvements**: Default values are resolved and validated before the main template processor is initialized. This includes restricting template expressions to environment variables and adding validation to ensure compatibility with declared input types. [[1]](diffhunk://#diff-94fcf2e4915df578e7e681c86049599ccbeae4a805259aaaec02e03fc602e2aaL138-R185) [[2]](diffhunk://#diff-1226e383ceff4a0462848d8a2b72e0e6da8dc6f9ef7daf6e25b0ca76903848a6L5-L60) [[3]](diffhunk://#diff-02f51937607cab74ff3e2ac2231525b38323461fa84f7819bfbdf6b79ca06c97L715-R727)

### Bug Fixes
* **Template Processing**: Fixed handling of unquoted literals in template expressions and improved error specificity by catching `ManifestError` instead of generic exceptions.

### Documentation and Examples
* **Updated Documentation**: Added details about templated default values and clarified evaluation order in the `README.md`.
* **Updated Examples**: Modified `inputs-pipeline.yml` to include examples of templated defaults.

### Miscellaneous
* **Version Update**: Bumped project version to `0.3.1` in `pyproject.toml`.
* **Test Updates**: Adjusted test cases to reflect changes in error messages for invalid input types. [[1]](diffhunk://#diff-938de46e643ab091cff6a7c23e4e752e8907e2266f47889d988923352f7a1058L80-R80) [[2]](diffhunk://#diff-938de46e643ab091cff6a7c23e4e752e8907e2266f47889d988923352f7a1058L104-R105)