### PR TITLE
release: v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2025-06-01
+
+### Fixed
+- **Documentation**: Improved README.md to include missing fields in the "Applicable fields for templating" section
+
 ## [0.4.0] - 2025-06-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -19,8 +19,13 @@ Deploy a pipeline of AWS SAM stacks using a YAML manifest with GitHub Actions-st
   - [Bootstrap an Existing Project](#bootstrap-an-existing-project)
   - [Advanced Validation Features](#advanced-validation-features)
 - [Manifest Reference](#manifest-reference) (Detailed)
-  - [Pipeline Inputs](#pipeline-inputs)
-  - [SAM Configuration Management](#sam-configuration-management)
+  - [Top-Level Structure](#top-level-structure)
+  - [pipeline_settings](#pipeline_settings)
+    - [Pipeline Inputs](#pipeline-inputs)
+    - [SAM Configuration Management](#sam-configuration-management)
+  - [stacks](#stacks)
+  - [Templating in Manifest Values](#templating-in-manifest-values)
+  - [Mathematical and Logical Expressions](#mathematical-and-logical-expressions)
 - [Troubleshooting / FAQ](#troubleshooting--faq)
 - [Development](#development)
 
@@ -256,7 +261,6 @@ The validator checks all manifest fields against the defined schema for known fi
 pipeline_settings:
   default_regionn: us-east-1 # ❌ Pydantic would report 'default_regionn' as an unexpected field.
 ```
-# Note: The previous custom typo suggestion (e.g. parameterss -> params) is now implicitly handled by Pydantic's strict field checking.
 
 #### Template Expression Validation
 
@@ -720,7 +724,16 @@ Several fields in the manifest support template substitution using the `${{ <exp
     *   An empty string (`''` or `""`) from a resolved variable or as a literal fallback is considered falsy by `||`, meaning the next part of the chain will be evaluated.
     *   If all parts of a fallback chain are falsy, the expression resolves to the value of the *last* part in the chain. If the last part was an unresolvable variable/output (resolved to `None`), the final result is an empty string. If the last part was a literal empty string (`''`), the result is that empty string.
 
-**Applicable fields for templating**: `pipeline_settings.stack_name_prefix`, `pipeline_settings.stack_name_suffix`, `stacks.params` values, `stacks.if` conditions, `stacks.run` script content, and `stacks.stack_name_suffix`.
+**Applicable fields for templating**:
+- `pipeline_settings.stack_name_prefix`
+- `pipeline_settings.stack_name_suffix`
+- `pipeline_settings.default_region`
+- `pipeline_settings.default_profile`
+- `stacks.params` values
+- `stacks.if` conditions
+- `stacks.run` script content
+- `stacks.stack_name_suffix`
+- String values within `pipeline_settings.default_sam_config` and `stacks.sam_config_overrides` (for `${{ env... }}`, `${{ inputs... }}`, and `${{ pipeline... }}` contexts)
 
 ### Mathematical and Logical Expressions
 


### PR DESCRIPTION
This pull request makes improvements to the documentation, specifically enhancing the README and CHANGELOG files. The changes include adding missing fields to the "Applicable fields for templating" section, restructuring the README table of contents for clarity, and updating examples to reflect stricter validation features.

### Documentation improvements:

* [`CHANGELOG.md`](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R12): Added a new entry for version 0.4.1, highlighting the improvement to the README's "Applicable fields for templating" section.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L723-R736): Expanded the "Applicable fields for templating" section to include additional fields such as `pipeline_settings.default_region`, `pipeline_settings.default_profile`, and string values within `pipeline_settings.default_sam_config` and `stacks.sam_config_overrides`.

### Structural enhancements:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R22-R28): Updated the table of contents to include new sub-sections like "Top-Level Structure," "pipeline_settings," "stacks," and "Templating in Manifest Values," improving navigation.

### Validation updates:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L259): Removed outdated notes on custom typo suggestions, emphasizing Pydantic's strict field checking for manifest validation.