### PR TITLE
Add docs site with Hugo

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,30 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      - name: Setup Hugo
+        uses: peaceiris/actions-hugo@v2
+        with:
+          hugo-version: '0.111.3'
+      - name: Build
+        run: hugo -s docs -d public
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: docs/public

--- a/.gitignore
+++ b/.gitignore
@@ -193,4 +193,4 @@ Thumbs.db
 
 # Auto-generated version file
 samstacks/version.py
-notes/
+docs/public/

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -1,4 +1,4 @@
 baseURL = "https://dev7a.github.io/samstacks"
 languageCode = "en-us"
 title = "samstacks"
-theme = "simple"
+theme = "ananke"

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -1,0 +1,4 @@
+baseURL = "https://dev7a.github.io/samstacks"
+languageCode = "en-us"
+title = "samstacks"
+theme = "simple"

--- a/docs/content/_index.md
+++ b/docs/content/_index.md
@@ -1,0 +1,7 @@
+---
+title: "Welcome"
+---
+
+**samstacks** is a YAML-driven pipeline tool for deploying AWS SAM stacks. It lets you define a sequence of stacks in a single manifest using a GitHub Actions style syntax.
+
+Use the navigation above to learn how to install, configure and run samstacks.

--- a/docs/content/cli/_index.md
+++ b/docs/content/cli/_index.md
@@ -1,0 +1,5 @@
+---
+title: "CLI"
+---
+
+samstacks provides several commands for deploying and managing pipelines.

--- a/docs/content/cli/bootstrap.md
+++ b/docs/content/cli/bootstrap.md
@@ -1,0 +1,9 @@
+---
+title: "Bootstrap"
+---
+
+```bash
+samstacks bootstrap [PATH_TO_SCAN] [OPTIONS]
+```
+
+Scans a directory for existing SAM projects and generates an initial `pipeline.yml` file. Useful options include `--output-file` to name the generated file and `--overwrite` to replace an existing file.

--- a/docs/content/cli/delete.md
+++ b/docs/content/cli/delete.md
@@ -1,0 +1,12 @@
+---
+title: "Delete"
+---
+
+```bash
+samstacks delete <manifest-file> [OPTIONS]
+```
+
+Deletes all stacks defined in the manifest in reverse order. Useful options:
+
+- `--no-prompts` to skip confirmation
+- `--dry-run` to preview deletions

--- a/docs/content/cli/deploy.md
+++ b/docs/content/cli/deploy.md
@@ -1,0 +1,17 @@
+---
+title: "Deploy"
+---
+
+```bash
+samstacks deploy <manifest-file> [OPTIONS]
+```
+
+Deploys all stacks defined in the manifest. Options include:
+
+- `--input <name=value>` to provide values for pipeline inputs
+- `--auto-delete-failed` to clean up failed stacks and changesets
+- `--report-file <PATH>` to save a Markdown summary
+- `--debug` for verbose logging
+- `--quiet` to suppress output
+
+Deployment reports include a console summary and optional Markdown file.

--- a/docs/content/cli/validate.md
+++ b/docs/content/cli/validate.md
@@ -1,0 +1,9 @@
+---
+title: "Validate"
+---
+
+```bash
+samstacks validate <manifest-file>
+```
+
+Performs comprehensive validation of the manifest including schema checks, template expressions, input definitions, stack dependencies and file existence.

--- a/docs/content/examples.md
+++ b/docs/content/examples.md
@@ -1,0 +1,22 @@
+---
+title: "Examples"
+---
+
+The [`examples/`](https://github.com/dev7a/samstacks/tree/main/examples) directory contains a comprehensive pipeline manifest demonstrating all features. It includes:
+
+- S3 bucket notifications to SQS
+- Lambda processing of uploaded files
+- Stack output dependencies
+- Centralized SAM configuration
+- Conditional deployment with `if`
+- Post-deployment scripts via `run`
+- Post-deployment summary output
+- Mathematical and logical expressions
+
+Try it with:
+
+```bash
+uvx samstacks deploy examples/pipeline.yml
+# or if installed
+samstacks deploy examples/pipeline.yml
+```

--- a/docs/content/examples.md
+++ b/docs/content/examples.md
@@ -2,7 +2,7 @@
 title: "Examples"
 ---
 
-The [`examples/`](https://github.com/dev7a/samstacks/tree/main/examples) directory contains a comprehensive pipeline manifest demonstrating all features. It includes:
+The [`examples/`](/examples/) directory contains a comprehensive pipeline manifest demonstrating all features. It includes:
 
 - S3 bucket notifications to SQS
 - Lambda processing of uploaded files

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -1,0 +1,5 @@
+---
+title: "FAQ"
+---
+
+For troubleshooting tips and frequently asked questions, see the project README and GitHub issues page.

--- a/docs/content/installation.md
+++ b/docs/content/installation.md
@@ -1,0 +1,21 @@
+---
+title: "Installation"
+---
+
+Recommended usage is via the [uv](https://docs.astral.sh/uv/) tool so you can run `samstacks` without installing:
+
+```bash
+uvx samstacks --help
+uvx samstacks deploy pipeline.yml
+```
+
+To install with pip:
+
+```bash
+python -m venv .venv  # or uv venv
+source .venv/bin/activate
+pip install samstacks  # or uv pip install samstacks
+samstacks --help
+```
+
+**Tip:** `uvx` provides the fastest way to get started with no virtual environment setup.

--- a/docs/content/manifest-reference.md
+++ b/docs/content/manifest-reference.md
@@ -1,0 +1,23 @@
+---
+title: "Manifest Reference"
+---
+
+A pipeline is described in a YAML file. Key fields include:
+
+```yaml
+pipeline_name: My SAM Application Deployment
+pipeline_description: Description of the pipeline
+summary: |-
+  Optional post deployment summary shown in console
+pipeline_settings:
+  stack_name_prefix: prefix-
+  default_region: us-east-1
+  inputs:
+    environment:
+      type: string
+stacks:
+  - id: backend
+    dir: backend
+```
+
+See the README for full details on all fields and templating rules.

--- a/docs/content/quickstart.md
+++ b/docs/content/quickstart.md
@@ -1,0 +1,39 @@
+---
+title: "Quick Start"
+---
+
+Create a manifest file `pipeline.yml`:
+
+```yaml
+pipeline_name: My SAM Application Deployment
+pipeline_description: Deploys the backend and frontend for My SAM Application.
+
+pipeline_settings:
+  default_sam_config:
+    version: 0.1
+    default:
+      deploy:
+        parameters:
+          capabilities: CAPABILITY_IAM
+          confirm_changeset: false
+
+stacks:
+  - id: backend
+    dir: my_sam_app/backend/
+    params:
+      TableName: ${{ env.TABLE_NAME || 'MyTable' }}
+  - id: frontend
+    dir: my_sam_app/frontend/
+    params:
+      ApiEndpoint: ${{ stacks.backend.outputs.ApiUrl }}
+```
+
+Deploy the pipeline:
+
+```bash
+uvx samstacks deploy pipeline.yml
+# or if installed
+samstacks deploy pipeline.yml
+```
+
+See the [Manifest Reference](/manifest-reference/) for more options.

--- a/docs/layouts/_default/baseof.html
+++ b/docs/layouts/_default/baseof.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <title>{{ .Title }} - samstacks</title>
+</head>
+<body>
+    <header>
+        <h1><a href="/">samstacks</a></h1>
+        <nav>
+            <a href="/installation/">Installation</a> |
+            <a href="/quickstart/">Quick Start</a> |
+            <a href="/examples/">Examples</a> |
+            <a href="/cli/">CLI</a> |
+            <a href="/manifest-reference/">Manifest Reference</a> |
+            <a href="/faq/">FAQ</a>
+        </nav>
+        <hr>
+    </header>
+    <main>
+        {{ block "main" . }}{{ end }}
+    </main>
+</body>
+</html>

--- a/docs/layouts/_default/single.html
+++ b/docs/layouts/_default/single.html
@@ -1,0 +1,5 @@
+{{ define "main" }}
+<article>
+{{ .Content }}
+</article>
+{{ end }}


### PR DESCRIPTION
## Summary
- create a new Hugo docs site under `docs/`
- add a GitHub Actions workflow to deploy the site to GitHub Pages
- ignore generated site directory
